### PR TITLE
Configurable batch sizes

### DIFF
--- a/scripts/cheese
+++ b/scripts/cheese
@@ -54,6 +54,27 @@ else
     SEARCH_TYPES=$search_types
 fi
 
+# Specify chunk size for inference
+if [ "$chunk_size" = "" ]; then
+    CHUNK_SIZE=100000
+else
+    CHUNK_SIZE=$chunk_size
+fi
+
+# Specify embeddings computation batch size for inference
+if [ "$batch_size" = "" ]; then
+    BATCH_SIZE=1024
+else
+    BATCH_SIZE=$batch_size
+fi
+
+# Specify clustering batch size for inference
+if [ "$clustering_batch_size" = "" ]; then
+    CLUSTERING_BS=10000
+else
+    CLUSTERING_BS=$clustering_batch_size
+fi
+
 
 
 if [ "$command" = "update_config" ]; then
@@ -73,7 +94,7 @@ else
         if [ "$HELP" = "--help" ]; then
             docker run -u $UID -it --entrypoint "python" -v /:/data --env PORT=$DB_PORT --env CONFIG_FILE=/data/$CONFIG_FILE --env LICENSING=True --env TRANSFORMERS_CACHE=/tmp --env CHEESE_LICENSE_FILE=/data/$LICENSE_FILE --rm $DB_IMAGE -c 'import cheese_database.cheese_cli as cli; cli.app();' $ALL_ARGS
         else
-            cheese-inference --input_file $input_file --dest $INFERENCE_OUTPUT_DIR --gpu_devices $GPU_DEVICES --valid_smiles $VALIDATE_SMILES --canonical_smiles $CANONICALIZE_SMILES --index_type $index_type
+            cheese-inference --input_file $input_file --dest $INFERENCE_OUTPUT_DIR --gpu_devices $GPU_DEVICES --valid_smiles $VALIDATE_SMILES --canonical_smiles $CANONICALIZE_SMILES --clustering_bs $CLUSTERING_BS --chunk_size $CHUNK_SIZE --batch_size $BATCH_SIZE --index_type $index_type
         fi
 
     elif [ "$command" = "embeddings_gpu" ]; then

--- a/scripts/cheese-inference
+++ b/scripts/cheese-inference
@@ -12,9 +12,6 @@ done
 EXTENSION=".csv"
 DELIMITER=","
 
-DEVICE="cuda"
-BATCH_SIZE=1024
-
 MAXSIZE=1000000
 
 INPUT_FILE=$input_file
@@ -41,11 +38,9 @@ fi
 
 
 
-CHUNK_SIZE=100000  # Chunk size for embeddings computation
-
 echo "Running CHEESE inference..."
 OUTPUT_DIRECTORY="/data/${dest}"
 NEW_OUTPUT_DIRECTORY="${dest}"
 echo Saving outputs to $NEW_OUTPUT_DIRECTORY
 mkdir $NEW_OUTPUT_DIRECTORY
-docker run -u $UID -v /:/data -it --env CUPY_CACHE_DIR=/tmp --env NCCL_SHM_DISABLE=1 --env CHEESE_LICENSE_FILE=/data/$LICENSE_FILE --env LICENSING=True --gpus all --rm $INFERENCE_IMAGE --index_type $INDEX_TYPE --input_file $DEST_INPUT_FILE --extension $EXTENSION --delimiter $DELIMITER --output_directory $OUTPUT_DIRECTORY --gpu_device_ids $gpu_devices --batch_size $BATCH_SIZE --chunk_size $CHUNK_SIZE --validate_smiles $valid_smiles --canonicalize_smiles $canonical_smiles
+docker run -u $UID -v /:/data -it --env CUPY_CACHE_DIR=/tmp --env NCCL_SHM_DISABLE=1 --env CHEESE_LICENSE_FILE=/data/$LICENSE_FILE --env LICENSING=True --gpus all --rm $INFERENCE_IMAGE --index_type $INDEX_TYPE --input_file $DEST_INPUT_FILE --extension $EXTENSION --delimiter $DELIMITER --output_directory $OUTPUT_DIRECTORY --gpu_device_ids $gpu_devices --batch_size $batch_size --chunk_size $clustering_bs --clustering_bs $clustering_bs --validate_smiles $valid_smiles --canonicalize_smiles $canonical_smiles


### PR DESCRIPTION
Adding tunable parameters to speed up the inference. Defaults are set for g4dn.xlarge instances or bigger.

- Batch size for embeddings computation : default 1024
- Batch size for cluster assignment : default 10K
- Chunk size for inference : default 100K